### PR TITLE
public htmx.request

### DIFF
--- a/Sources/VHX/Htmx/Htmx.swift
+++ b/Sources/VHX/Htmx/Htmx.swift
@@ -5,7 +5,7 @@ public struct Htmx {
         case htmx, html, api
     }
 
-    let req: Request
+    public let req: Request
 
     public let response: HXResponseConfiguration
 }


### PR DESCRIPTION
Hello!

I'd like to extend `Htmx` to add my own render methods. In order to do this, I need access to `Htmx.request`.

This change exposes `Htmx.request` as `public`. Not that it is still immutable and thus cannot be changed after init.